### PR TITLE
`RadioGroup` 컴포넌트 추가

### DIFF
--- a/apps/docs/stories/components/radio-group/radio-group.docs.mdx
+++ b/apps/docs/stories/components/radio-group/radio-group.docs.mdx
@@ -1,0 +1,30 @@
+import { Meta, Primary, Controls, Source } from '@storybook/blocks';
+import * as RadioGroupStories from './radio-group.stories';
+
+<Meta of={RadioGroupStories} />
+
+# RadioGroup
+
+<Primary />
+
+## Props
+
+<Controls />
+
+## Usage
+
+### Import
+
+<Source
+  code={`import { RadioGroup, RadioGroupItem } from '@figma-plugins/ui';`}
+/>
+
+### Anatomy
+
+<Source
+  code={`
+<RadioGroup>
+  <RadioGroupItem />
+</RadioGroup>
+  `}
+/>

--- a/apps/docs/stories/components/radio-group/radio-group.stories.tsx
+++ b/apps/docs/stories/components/radio-group/radio-group.stories.tsx
@@ -1,0 +1,48 @@
+import { Text, Flex, RadioGroup, RadioGroupItem } from '@figma-plugins/ui';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/Radio Group',
+  component: RadioGroup,
+  argTypes: {
+    disabled: {
+      control: 'boolean',
+    },
+  },
+} satisfies Meta<typeof RadioGroup>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <form>
+      <RadioGroup {...args} aria-label="View density" defaultValue="default">
+        <Flex gap="400" items="center">
+          <Flex gap="100" items="center">
+            <RadioGroupItem id="r1" value="default" />
+            <Text as="label" htmlFor="r1" size="sm" weight="medium">
+              Default
+            </Text>
+          </Flex>
+          <Flex gap="100" items="center">
+            <RadioGroupItem id="r2" value="compact" />
+            <Text as="label" htmlFor="r2" size="sm" weight="medium">
+              Compact
+            </Text>
+          </Flex>
+          <Flex gap="100" items="center">
+            <RadioGroupItem id="r3" value="comportable" />
+            <Text as="label" htmlFor="r3" size="sm" weight="medium">
+              Comportable
+            </Text>
+          </Flex>
+        </Flex>
+      </RadioGroup>
+    </form>
+  ),
+  args: {
+    disabled: false,
+  },
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@radix-ui/react-radio-group": "^1.1.3",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -7,3 +7,4 @@ export { Toaster, useToast } from './toaster';
 export { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs';
 export { ScrollArea } from './scroll-area';
 export { Loader, type LoaderProps } from './loader';
+export { RadioGroup, RadioGroupItem } from './radio-group';

--- a/packages/ui/src/components/radio-group.tsx
+++ b/packages/ui/src/components/radio-group.tsx
@@ -1,0 +1,67 @@
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import { forwardRef } from 'react';
+import { styled } from '@/stitches.config';
+import { colors } from '@/vars';
+
+export const RadioGroup = styled(RadioGroupPrimitive.Root, {
+  display: 'flex',
+});
+
+const StyledRadioGroupItem = styled(RadioGroupPrimitive.Item, {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '$500',
+  height: '$500',
+  borderRadius: '$full',
+  borderWidth: '$1',
+  borderColor: colors.border.default,
+  backgroundColor: 'transparent',
+  transitionProperty: '$transitions$colors',
+  transitionDuration: '$transitions$200',
+  transitionTimingFunction: '$transitions$ease-out',
+  '&:focus-visible': {
+    outline: 'none',
+    boxShadow: `inset 0 0 0 1px ${colors.border.selected.default}`,
+  },
+  '&:hover': {
+    backgroundColor: colors.bg.hover,
+  },
+  '&:disabled': {
+    cursor: 'not-allowed',
+    backgroundColor: colors.bg.disabled.default,
+  },
+  '&[data-state="checked"]': {
+    borderColor: colors.border.selected.default,
+  },
+  '&:hover[data-state="checked"]': {
+    backgroundColor: colors.bg.selected.hover,
+  },
+  '&:disabled[data-state="checked"]': {
+    borderColor: colors.border.disabled.default,
+  },
+});
+
+<RadioGroupPrimitive.Indicator className="bg-figma-bg-brand block h-2.5 w-2.5 rounded-full" />;
+
+const StyledRadioGroupIndicator = styled(RadioGroupPrimitive.Indicator, {
+  width: '$250',
+  height: '$250',
+  borderRadius: '$full',
+  backgroundColor: colors.icon.selected.default,
+  '&[data-disabled]': {
+    backgroundColor: colors.icon.disabled,
+  },
+});
+
+export const RadioGroupItem = forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>((props, ref) => {
+  return (
+    <StyledRadioGroupItem ref={ref} {...props}>
+      <StyledRadioGroupIndicator />
+    </StyledRadioGroupItem>
+  );
+});
+RadioGroupItem.displayName = 'RadioGroupItem';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@radix-ui/react-radio-group':
+        specifier: ^1.1.3
+        version: 1.1.3(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-scroll-area':
         specifier: ^1.0.5
         version: 1.0.5(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
@@ -2440,6 +2443,36 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
+  /@radix-ui/react-radio-group@1.1.3(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-x+yELayyefNeKeTx4fjK6j99Fs6c4qKm3aY38G3swQVTN6xMpsrbigC0uHs2L//g8q4qR7qOcww8430jJmi2ag==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@types/react': 18.2.33
+      '@types/react-dom': 18.2.14
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-roving-focus@1.0.4(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==}
     peerDependencies:
@@ -2776,7 +2809,6 @@ packages:
       '@babel/runtime': 7.23.2
       '@types/react': 18.2.33
       react: 18.2.0
-    dev: true
 
   /@radix-ui/react-use-rect@1.0.1(@types/react@18.2.33)(react@18.2.0):
     resolution: {integrity: sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==}
@@ -2806,7 +2838,6 @@ packages:
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.33)(react@18.2.0)
       '@types/react': 18.2.33
       react: 18.2.0
-    dev: true
 
   /@radix-ui/react-visually-hidden@1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==}


### PR DESCRIPTION
## 변경사항
- `@radix-ui/react-radio-group` 기반 `RadioGroup`, `RadioGroupItem` 컴포넌트 추가
- `RadioGroup` 관련 `Story` 및 `Docs` 추가

## 참조
- https://www.radix-ui.com/primitives/docs/components/radio-group