### PR TITLE
`Popover` 컴포넌트 추가

### DIFF
--- a/apps/docs/stories/components/popover/popover.docs.mdx
+++ b/apps/docs/stories/components/popover/popover.docs.mdx
@@ -1,0 +1,37 @@
+import { Meta, Primary, Controls, Story, Source } from '@storybook/blocks';
+import * as PopoverStories from './popover.stories';
+
+<Meta of={PopoverStories} />
+
+# Popover
+
+<Primary />
+
+## Props
+
+<Controls />
+
+## Usage
+
+### Import
+
+<Source
+  code={`import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverClose,
+} from '@figma-plugins/ui';`}
+/>
+
+### Anatomy
+
+<Source
+  code={`
+<Popover>
+  <PopoverTrigger />
+  <PopoverContent>
+    <PopoverClose />
+  </PopoverContent>
+</Popover>`}
+/>

--- a/apps/docs/stories/components/popover/popover.stories.tsx
+++ b/apps/docs/stories/components/popover/popover.stories.tsx
@@ -1,0 +1,45 @@
+import {
+  Flex,
+  Text,
+  Button,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@figma-plugins/ui';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/Popover',
+  component: Popover,
+  argTypes: {
+    modal: {
+      control: 'boolean',
+    },
+  },
+} satisfies Meta<typeof Popover>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Popover {...args}>
+      <PopoverTrigger asChild>
+        <Button type="button">Open popover</Button>
+      </PopoverTrigger>
+      <PopoverContent side="top">
+        <Flex direction="column" gap="100">
+          <Text weight="bold">Popover</Text>
+          <Text size="sm" variant="secondary">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis
+            gravida hendrerit ante et convallis.
+          </Text>
+        </Flex>
+      </PopoverContent>
+    </Popover>
+  ),
+  args: {
+    modal: false,
+  },
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-radio-group": "^1.1.3",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-select": "^2.0.0",

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,10 +1,9 @@
 export { Box } from './box';
 export { Button, type ButtonVariantProps } from './button';
 export { Flex, type FlexVariantProps } from './flex';
-export { Text, type TextVariantProps } from './text';
-export { Toast, type ToastProps } from './toast';
-export { Toaster, useToast } from './toaster';
-export { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs';
+export { Loader, type LoaderProps } from './loader';
+export { Popover, PopoverTrigger, PopoverContent } from './popover';
+export { RadioGroup, RadioGroupItem } from './radio-group';
 export { ScrollArea } from './scroll-area';
 export {
   Select,
@@ -16,5 +15,7 @@ export {
   SelectItem,
   SelectSeparator,
 } from './select';
-export { Loader, type LoaderProps } from './loader';
-export { RadioGroup, RadioGroupItem } from './radio-group';
+export { Text, type TextVariantProps } from './text';
+export { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs';
+export { Toast, type ToastProps } from './toast';
+export { Toaster, useToast } from './toaster';

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -1,0 +1,76 @@
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import React, { forwardRef } from 'react';
+import { Cross2Icon } from '@radix-ui/react-icons';
+import { styled } from '@/stitches.config';
+import { animations, colors } from '@/vars';
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverClose = PopoverPrimitive.Close;
+
+const StyledPopoverContent = styled(PopoverPrimitive.Content, {
+  position: 'relative',
+  zIndex: '$popover',
+  width: '16rem',
+  padding: '$400',
+  borderWidth: '$1',
+  borderRadius: '$lg',
+  backgroundColor: colors.bg.default,
+  boxShadow: '$md',
+  outline: 'none',
+  animationDuration: '300ms',
+  animationTimingFunction: '$transitions$ease-out',
+  willChange: 'transform, opacity',
+  '&[data-state="open"]': {
+    '&[data-side="top"]': {
+      animationName: animations.appearFromBottom,
+    },
+    '&[data-side="right"]': {
+      animationName: animations.appearFromLeft,
+    },
+    '&[data-side="bottom"]': {
+      animationName: animations.appearFromTop,
+    },
+    '&[data-side="left"]': {
+      animationName: animations.appearFromRight,
+    },
+  },
+});
+
+const StyledPopoverClose = styled(PopoverPrimitive.Close, {
+  position: 'absolute',
+  top: '$100',
+  right: '$100',
+  padding: '$100',
+  color: colors.icon.secondary.default,
+  transitionProperty: '$transitions$colors',
+  transitionDuration: '$transitions$200',
+  transitionTimingFunction: '$transitions$ease-out',
+  '&:hover': {
+    color: colors.icon.secondary.hover,
+  },
+});
+
+const PopoverContent = forwardRef<
+  React.ElementRef<typeof StyledPopoverContent>,
+  React.ComponentPropsWithoutRef<typeof StyledPopoverContent>
+>(({ align = 'center', sideOffset = 4, children, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <StyledPopoverContent
+      align={align}
+      ref={ref}
+      sideOffset={sideOffset}
+      {...props}
+    >
+      {children}
+      <StyledPopoverClose aria-label="Close popover" type="button">
+        <Cross2Icon height={16} width={16} />
+      </StyledPopoverClose>
+    </StyledPopoverContent>
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverClose, PopoverContent };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@radix-ui/react-popover':
+        specifier: ^1.0.7
+        version: 1.0.7(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-radio-group':
         specifier: ^1.1.3
         version: 1.1.3(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
@@ -2348,6 +2351,41 @@ packages:
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.33)(react@18.2.0)
       '@types/react': 18.2.33
       react: 18.2.0
+
+  /@radix-ui/react-popover@1.0.7(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-shtvVnlsxT6faMnK/a7n0wptwBD23xc1Z5mdrtKLwVEfsEMXodS0r5s0/g5P0hX//EKYZS2sxUjqfzlg52ZSnQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.4(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-popper': 1.1.3(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@types/react': 18.2.33
+      '@types/react-dom': 18.2.14
+      aria-hidden: 1.2.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.5.5(@types/react@18.2.33)(react@18.2.0)
+    dev: false
 
   /@radix-ui/react-popper@1.1.2(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-1CnGGfFi/bbqtJZZ0P/NQY20xdG3E0LALJaLUEoKwPLwl6PPPfbeiCqMVQnhoFRAxjJj4RpBRJzDmUgsex2tSg==}


### PR DESCRIPTION
## 변경사항
- `@radix-ui/react-popover` 기반 `Popover` 컴포넌트 추가
  - `Popover`, `PopoverTrigger`, `PopoverContent`, `PopoverClose` 추가
- `Popover` 컴포넌트에 대한 `Story` 및 `Docs` 추가

## 참조
- https://www.radix-ui.com/primitives/docs/components/popover