### PR TITLE
`fontWeight` 관련 token 변경

### DIFF
--- a/packages/ui/src/tokens/font.ts
+++ b/packages/ui/src/tokens/font.ts
@@ -31,9 +31,9 @@ export const lineHeights = {
 };
 
 export const fontWeights = {
-  regular: 450,
-  medium: 550,
-  semibold: 650,
+  regular: 400,
+  medium: 500,
+  semibold: 600,
   bold: 700,
 };
 


### PR DESCRIPTION
## 변경사항
- `fontWeights`를 위한 `token`의 단위 변경
- `figma` 내에서 `Inter` 폰트에 대한, `Variable Font`를 제공하지 않아서 제대로 적용되지 않는 문제 수정
