### PR TITLE
`@figma-plugins/docs`의 스타일 관련 수정

### DIFF
--- a/apps/docs/.storybook/decorators/with-layout.tsx
+++ b/apps/docs/.storybook/decorators/with-layout.tsx
@@ -1,23 +1,50 @@
-import { Box, colors } from '@figma-plugins/ui';
+import { Flex } from '@figma-plugins/ui';
 import type { Decorator } from '@storybook/react';
 
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+function DocsLayout({ children }: LayoutProps) {
+  return (
+    <Flex
+      css={{
+        minHeight: '16rem',
+        alignContent: 'center',
+        padding: '$1000',
+      }}
+      gap="400"
+      items="center"
+      justify="center"
+      wrap="wrap"
+    >
+      {children}
+    </Flex>
+  );
+}
+
+function StoryLayout({ children }: LayoutProps) {
+  return (
+    <Flex
+      css={{
+        alignContent: 'center',
+        padding: '$500',
+      }}
+      gap="400"
+      items="center"
+      wrap="wrap"
+    >
+      {children}
+    </Flex>
+  );
+}
+
 export const withLayout: Decorator = (StoryFn, context) => {
-  const isStory = context.viewMode === 'story';
+  const Layout = context.viewMode === 'docs' ? DocsLayout : StoryLayout;
 
   return (
-    <Box
-      css={{
-        height: isStory ? '100vh' : '$full',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        alignContent: 'center',
-        flexWrap: 'wrap',
-        gap: '$400',
-        backgroundColor: colors.bg.default,
-      }}
-    >
+    <Layout>
       <StoryFn />
-    </Box>
+    </Layout>
   );
 };

--- a/apps/docs/.storybook/head.ts
+++ b/apps/docs/.storybook/head.ts
@@ -6,9 +6,18 @@ export const managerHead = (head: string) => {
       property="og:description"
       content="Design System for Figma Plugins."
     />
-    <link
-      rel="stylesheet"
-      href="/styles/manager.css"
-    />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="/styles/manager.css" rel="stylesheet" />
+  `;
+};
+
+export const previewHead = (head: string) => {
+  return `
+    ${head}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   `;
 };

--- a/apps/docs/.storybook/head.ts
+++ b/apps/docs/.storybook/head.ts
@@ -9,7 +9,7 @@ export const managerHead = (head: string) => {
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link href="/styles/manager.css" rel="stylesheet" />
+    <link href="./styles/manager.css" rel="stylesheet" />
   `;
 };
 

--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -1,6 +1,6 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 import { mergeConfig } from 'vite';
-import { managerHead } from './head';
+import { managerHead, previewHead } from './head';
 
 const storybookConfig: StorybookConfig = {
   framework: '@storybook/react-vite',
@@ -22,6 +22,7 @@ const storybookConfig: StorybookConfig = {
     reactDocgen: 'react-docgen',
   },
   managerHead,
+  previewHead,
   viteFinal(config) {
     return mergeConfig(config, {
       build: {

--- a/apps/docs/.storybook/preview.ts
+++ b/apps/docs/.storybook/preview.ts
@@ -39,7 +39,6 @@ const preview: Preview = {
     },
   },
   decorators: [
-    withGlobalStyles,
     withThemeByClassName({
       themes: {
         light: 'figma-light',
@@ -47,6 +46,7 @@ const preview: Preview = {
       },
       defaultTheme: 'light',
     }),
+    withGlobalStyles,
     withLayout,
   ],
 };

--- a/apps/docs/.storybook/styles/docs.css
+++ b/apps/docs/.storybook/styles/docs.css
@@ -6,23 +6,31 @@
   max-width: 65ch;
 }
 
-.docs-story {
+/* Canvas, Primary 관련 스타일  */
+.sbdocs.sbdocs-preview {
+  box-shadow: none;
+}
+
+/* ArgTypes, Controls 관련 스타일 */
+.sbdocs .docblock-argstable {
+  border-collapse: separate;
+}
+.sbdocs .docblock-argstable > .docblock-argstable-body {
+  filter: none;
+}
+
+/* Story 관련 스타일 */
+.sbdocs .sb-story {
   background-color: var(--figma-color-bg);
 }
 
-.sbdocs [data-story-block='true'] {
+.sbdocs :is(.sb-story:not(.sbdocs-preview .sb-story)) {
   border-width: 1px;
   border-color: var(--figma-color-border);
+  border-radius: 0.375rem;
 }
 
-.sbdocs .innerZoomElementWrapper [data-story-block='true'] {
-  border: none;
-}
-
-.sbdocs [data-story-block='true'] > [data-name] {
-  height: 16rem;
-}
-
+/* Markdown 관련 스타일 */
 .sbdocs :is(h1:not(.sb-anchor, .sb-unstyled, .sb-unstyled h1)) {
   font-size: 2rem;
   line-height: 2.5rem;

--- a/apps/docs/.storybook/theme.ts
+++ b/apps/docs/.storybook/theme.ts
@@ -3,7 +3,7 @@ import { create } from '@storybook/theming/create';
 export const theme = create({
   base: 'light',
 
-  brandUrl: '/',
+  brandUrl: './',
   brandTarget: '_self',
 
   fontBase:

--- a/apps/docs/.storybook/theme.ts
+++ b/apps/docs/.storybook/theme.ts
@@ -17,7 +17,7 @@ export const theme = create({
   appBg: '#f5f5f5',
   appContentBg: 'rgba(255, 255, 255, 1)',
   appBorderColor: '#e6e6e6',
-  appBorderRadius: 0,
+  appBorderRadius: 6,
 
   textColor: 'rgba(0, 0, 0, 0.9)',
   textInverseColor: 'rgba(255, 255, 255, 0.9)',
@@ -29,5 +29,5 @@ export const theme = create({
   inputBg: 'transparent',
   inputBorder: '#e6e6e6',
   inputTextColor: 'rgba(0, 0, 0, 0.9)',
-  inputBorderRadius: 4,
+  inputBorderRadius: 6,
 });


### PR DESCRIPTION
## 변경사항
- Github Pages에서 `manager.css` 제대로 적용되지 않는 문제 수정
- Storybook내에서 `Inter` 폰트 제대로 적용되지 않는 문제 수정
  - `managerHead` 및 `previewHead` 내의 폰트 관련 `<link>` 태그 추가 
- Storybook내의 문서에 존재하는 `Story`의 레이아웃 관련 문제 수정
  - 일정 높이 이상 넘어가는 경우 제대로 보여지지 않는 문제 수정
  - `Story`와 `Docs`내의 `Story`에 따른 서로 다른 스타일 적용
- 문서 내의 스타일 통일화
  - `Storyboook`의 기존 스타일을 `docs.css`에서 수정
  - `theme`에서 `borderRadius`를 같게 수정