### PR TITLE
한글입숨 플러그인 UI 추가

### DIFF
--- a/plugins/korean-ipsum/package.json
+++ b/plugins/korean-ipsum/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@figma-plugins/ui": "workspace:*",
+    "@radix-ui/react-icons": "^1.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/plugins/korean-ipsum/src/ui/pages/form-page.tsx
+++ b/plugins/korean-ipsum/src/ui/pages/form-page.tsx
@@ -1,0 +1,122 @@
+import {
+  Button,
+  Flex,
+  RadioGroup,
+  RadioGroupItem,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Text,
+} from '@figma-plugins/ui';
+import type { ComponentPropsWithoutRef } from 'react';
+import { useId } from 'react';
+
+const GENERATE_SOURCES = [
+  { value: 'countingStars', label: '별 헤는 밤' },
+  { value: 'mountain', label: '청산도' },
+  { value: 'shower', label: '소나기' },
+  { value: 'star', label: '별' },
+] as const;
+
+const GENREATE_UNITS = [
+  { value: 'word', label: '단어' },
+  { value: 'sentence', label: '문장' },
+  { value: 'paragraph', label: '문단' },
+] as const;
+
+const GENERATE_COUNTS = [
+  { value: '1', label: '1개' },
+  { value: '2', label: '2개' },
+  { value: '3', label: '3개' },
+  { value: '4', label: '4개' },
+  { value: '5', label: '5개' },
+] as const;
+
+const GENERATE_METHODS = [
+  { value: 'replace', label: '덮어쓰기' },
+  { value: 'join', label: '이어붙이기' },
+] as const;
+
+interface RadioGroupFieldProps
+  extends ComponentPropsWithoutRef<typeof RadioGroup> {
+  title: string;
+  options: readonly { value: string; label: string }[];
+}
+
+function RadioGroupField({ title, options, ...props }: RadioGroupFieldProps) {
+  const id = useId();
+
+  return (
+    <div>
+      <Text css={{ marginBottom: '$250' }} size="sm" weight="semibold">
+        {title}
+      </Text>
+      <RadioGroup {...props}>
+        {options.map(({ value, label }) => (
+          <Flex css={{ flex: 1 }} gap="150" items="center" key={value}>
+            <RadioGroupItem id={`${id}-${value}`} value={value} />
+            <Text
+              as="label"
+              htmlFor={`${id}-${value}`}
+              size="sm"
+              weight="semibold"
+            >
+              {label}
+            </Text>
+          </Flex>
+        ))}
+      </RadioGroup>
+    </div>
+  );
+}
+
+export function FormPage() {
+  return (
+    <Flex
+      css={{ padding: '$400', height: '100vh' }}
+      direction="column"
+      gap="600"
+      justify="between"
+    >
+      <Flex direction="column" gap="700">
+        <Flex direction="column" gap="200">
+          <Text as="label" htmlFor="text-source" size="sm" weight="semibold">
+            텍스트 소스
+          </Text>
+          <Select>
+            <SelectTrigger id="text-source">
+              <SelectValue placeholder="텍스트 소스를 선택해주세요." />
+            </SelectTrigger>
+            <SelectContent position="popper">
+              {GENERATE_SOURCES.map(({ value, label }) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Flex>
+        <RadioGroupField
+          id="generate-unit"
+          options={GENREATE_UNITS}
+          title="생성 단위"
+        />
+        <RadioGroupField
+          id="generate-count"
+          options={GENERATE_COUNTS}
+          title="생성 개수"
+        />
+        <RadioGroupField
+          id="generate-method"
+          options={GENERATE_METHODS}
+          title="생성 방식"
+        />
+      </Flex>
+      <Button size="sm" type="button">
+        생성
+      </Button>
+    </Flex>
+  );
+}

--- a/plugins/korean-ipsum/src/ui/pages/index.ts
+++ b/plugins/korean-ipsum/src/ui/pages/index.ts
@@ -1,0 +1,1 @@
+export { MainPage } from './main-page';

--- a/plugins/korean-ipsum/src/ui/pages/index.ts
+++ b/plugins/korean-ipsum/src/ui/pages/index.ts
@@ -1,1 +1,2 @@
+export { FormPage } from './form-page';
 export { MainPage } from './main-page';

--- a/plugins/korean-ipsum/src/ui/pages/main-page.tsx
+++ b/plugins/korean-ipsum/src/ui/pages/main-page.tsx
@@ -1,0 +1,33 @@
+import { Box, Flex, NodeBadge, Text } from '@figma-plugins/ui';
+
+export function MainPage() {
+  return (
+    <Flex
+      css={{ height: '100vh', padding: '$300', position: 'relative' }}
+      direction="column"
+    >
+      <Box as="header">
+        <Text size="sm" weight="semibold">
+          한글입숨
+        </Text>
+      </Box>
+      <Flex
+        as="main"
+        css={{ flex: 1, paddingBottom: '$500' }}
+        direction="column"
+        items="center"
+        justify="center"
+      >
+        <Flex gap="100" items="center">
+          <Text as="span" size="sm">
+            텍스트를 생성하고자 하는
+          </Text>
+          <NodeBadge nodeType="text" />
+          <Text as="span" size="sm">
+            선택해주세요.
+          </Text>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       '@figma-plugins/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@radix-ui/react-icons':
+        specifier: ^1.3.0
+        version: 1.3.0(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0


### PR DESCRIPTION
## 변경사항
- 한글입숨 플러그인(`korean-ipsum`)에 필요한 UI 구현
  - `MainPage`, `FormPage` 추가
  - `MainPage`: 텍스트 노드를 선택하기 전에 보여지는 화면 구성
  - `FormPage`: 한글 텍스트를 생성 관련 폼을 보여지는 화면 구성
 