### PR TITLE
`clientStorage` 동기화 기능 추가

### DIFF
--- a/plugins/korean-ipsum/src/code/handlers.ts
+++ b/plugins/korean-ipsum/src/code/handlers.ts
@@ -1,0 +1,40 @@
+import type { GenerateFormState, UIPluginMessage } from '@/shared/types';
+import { getClientStorage, setClientStorage } from './utils/client-storage';
+import { postFigmaPluginMessage } from './utils/plugin-message';
+import { isTextNode } from './utils/check-node';
+
+function getIsSelectedTextNode() {
+  return figma.currentPage.selection.some(isTextNode);
+}
+
+function getFormStateFromClientStorage(): Promise<GenerateFormState> {
+  return getClientStorage('FORM_STATE', {
+    source: 'countingStars',
+    unit: 'word',
+    count: '1',
+    method: 'replace',
+  });
+}
+
+export function selectionChangeHandler() {
+  postFigmaPluginMessage({
+    type: 'ON_CHANGE_SELECTION',
+    isSelectedTextNode: getIsSelectedTextNode(),
+  });
+}
+
+export async function messageEventHandler(msg: UIPluginMessage) {
+  switch (msg.type) {
+    case 'INIT':
+      postFigmaPluginMessage({
+        type: 'ON_INIT',
+        isSelectedTextNode: getIsSelectedTextNode(),
+        formState: await getFormStateFromClientStorage(),
+      });
+      return;
+    case 'ON_CHANGE_FORM_STATE':
+      return setClientStorage('FORM_STATE', msg.formState);
+    default:
+      break;
+  }
+}

--- a/plugins/korean-ipsum/src/code/index.ts
+++ b/plugins/korean-ipsum/src/code/index.ts
@@ -1,6 +1,8 @@
 import manifest from 'manifest.json';
+import type { GenerateFormState, UIPluginMessage } from '@/shared/types';
 import { postFigmaPluginMessage } from './utils/plugin-message';
 import { isTextNode } from './utils/check-node';
+import { getClientStorage, setClientStorage } from './utils/client-storage';
 
 figma.showUI(__html__, {
   title: manifest.name,
@@ -15,3 +17,30 @@ figma.on('selectionchange', () => {
     isSelectedTextNode: figma.currentPage.selection.some(isTextNode),
   });
 });
+
+async function messageEventHandler(msg: UIPluginMessage) {
+  switch (msg.type) {
+    case 'INIT':
+      postFigmaPluginMessage({
+        type: 'ON_INIT',
+        isSelectedTextNode: figma.currentPage.selection.some(isTextNode),
+        formState: await getClientStorage<GenerateFormState>('FORM_STATE', {
+          source: 'countingStars',
+          unit: 'word',
+          count: '1',
+          method: 'replace',
+        }),
+      });
+      break;
+    case 'ON_CHANGE_FORM_STATE':
+      await setClientStorage('FORM_STATE', msg.formState);
+      break;
+    default:
+      break;
+  }
+}
+
+figma.ui.onmessage = (msg: UIPluginMessage) => {
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises -- TODO: Add handling Errors
+  messageEventHandler(msg);
+};

--- a/plugins/korean-ipsum/src/code/index.ts
+++ b/plugins/korean-ipsum/src/code/index.ts
@@ -1,8 +1,6 @@
 import manifest from 'manifest.json';
-import type { GenerateFormState, UIPluginMessage } from '@/shared/types';
-import { postFigmaPluginMessage } from './utils/plugin-message';
-import { isTextNode } from './utils/check-node';
-import { getClientStorage, setClientStorage } from './utils/client-storage';
+import type { UIPluginMessage } from '@/shared/types';
+import { messageEventHandler, selectionChangeHandler } from './handlers';
 
 figma.showUI(__html__, {
   title: manifest.name,
@@ -11,36 +9,10 @@ figma.showUI(__html__, {
   height: 432,
 });
 
-figma.on('selectionchange', () => {
-  postFigmaPluginMessage({
-    type: 'ON_CHANGE_SELECTION',
-    isSelectedTextNode: figma.currentPage.selection.some(isTextNode),
+figma.on('selectionchange', selectionChangeHandler);
+
+figma.ui.onmessage = (pluginMessage: UIPluginMessage) => {
+  messageEventHandler(pluginMessage).catch(() => {
+    /**TODO: Add Error Handling */
   });
-});
-
-async function messageEventHandler(msg: UIPluginMessage) {
-  switch (msg.type) {
-    case 'INIT':
-      postFigmaPluginMessage({
-        type: 'ON_INIT',
-        isSelectedTextNode: figma.currentPage.selection.some(isTextNode),
-        formState: await getClientStorage<GenerateFormState>('FORM_STATE', {
-          source: 'countingStars',
-          unit: 'word',
-          count: '1',
-          method: 'replace',
-        }),
-      });
-      break;
-    case 'ON_CHANGE_FORM_STATE':
-      await setClientStorage('FORM_STATE', msg.formState);
-      break;
-    default:
-      break;
-  }
-}
-
-figma.ui.onmessage = (msg: UIPluginMessage) => {
-  // eslint-disable-next-line @typescript-eslint/no-floating-promises -- TODO: Add handling Errors
-  messageEventHandler(msg);
 };

--- a/plugins/korean-ipsum/src/code/utils/client-storage.ts
+++ b/plugins/korean-ipsum/src/code/utils/client-storage.ts
@@ -1,0 +1,19 @@
+const STORAGE_KEYS = {
+  FORM_STATE: 'korean-ipsum_form-state',
+} as const;
+
+type StorageKey = keyof typeof STORAGE_KEYS;
+
+export async function getClientStorage<T>(key: StorageKey, defaultValue: T) {
+  const value = (await figma.clientStorage.getAsync(STORAGE_KEYS[key])) as
+    | T
+    | undefined;
+  if (value === undefined) {
+    return defaultValue;
+  }
+  return value;
+}
+
+export function setClientStorage<T>(key: StorageKey, value: T) {
+  return figma.clientStorage.setAsync(STORAGE_KEYS[key], value);
+}

--- a/plugins/korean-ipsum/src/shared/types/plugin-message.ts
+++ b/plugins/korean-ipsum/src/shared/types/plugin-message.ts
@@ -1,3 +1,5 @@
+import type { GenerateFormState } from './generate-form';
+
 export type FigmaPluginMessageType = 'ON_CHANGE_SELECTION';
 
 /**
@@ -6,4 +8,11 @@ export type FigmaPluginMessageType = 'ON_CHANGE_SELECTION';
 export interface FigmaPluginMessage {
   type: 'ON_CHANGE_SELECTION';
   isSelectedTextNode: boolean;
+}
+
+export type UIPluginMessageType = 'ON_CHANGE_FORM_STATE';
+
+export interface UIPluginMessage {
+  type: 'ON_CHANGE_FORM_STATE';
+  formState: GenerateFormState;
 }

--- a/plugins/korean-ipsum/src/shared/types/plugin-message.ts
+++ b/plugins/korean-ipsum/src/shared/types/plugin-message.ts
@@ -1,18 +1,26 @@
 import type { GenerateFormState } from './generate-form';
 
-export type FigmaPluginMessageType = 'ON_CHANGE_SELECTION';
+export type FigmaPluginMessageType = 'ON_INIT' | 'ON_CHANGE_SELECTION';
 
 /**
  * PluginMessage for figma(sandbox) → ui(ifra
  */
-export interface FigmaPluginMessage {
-  type: 'ON_CHANGE_SELECTION';
-  isSelectedTextNode: boolean;
-}
+export type FigmaPluginMessage =
+  | {
+      type: 'ON_INIT';
+      isSelectedTextNode: boolean;
+      formState: GenerateFormState;
+    }
+  | {
+      type: 'ON_CHANGE_SELECTION';
+      isSelectedTextNode: boolean;
+    };
 
-export type UIPluginMessageType = 'ON_CHANGE_FORM_STATE';
+export type UIPluginMessageType = 'INIT' | 'ON_CHANGE_FORM_STATE';
 
-export interface UIPluginMessage {
-  type: 'ON_CHANGE_FORM_STATE';
-  formState: GenerateFormState;
-}
+export type UIPluginMessage =
+  | { type: 'INIT' }
+  | {
+      type: 'ON_CHANGE_FORM_STATE';
+      formState: GenerateFormState;
+    };

--- a/plugins/korean-ipsum/src/ui/app.tsx
+++ b/plugins/korean-ipsum/src/ui/app.tsx
@@ -1,15 +1,29 @@
-import { globalStyles } from '@figma-plugins/ui';
+import { Flex, Loader, colors, globalStyles } from '@figma-plugins/ui';
 import { FormPage, MainPage } from './pages';
 import { useMessageEventListener } from './hooks';
 import { useGlobalStore } from './store';
 
 export function App() {
+  const { isLoading } = useMessageEventListener();
   const isSelectedTextNode = useGlobalStore(
     (state) => state.isSelectedTextNode,
   );
-
   globalStyles();
-  useMessageEventListener();
+
+  if (isLoading) {
+    return (
+      <Flex css={{ height: '100vh' }} items="center" justify="center">
+        <Loader
+          animate
+          css={{
+            color: colors.icon.secondary.default,
+          }}
+          height="24"
+          width="24"
+        />
+      </Flex>
+    );
+  }
 
   return <>{isSelectedTextNode ? <FormPage /> : <MainPage />}</>;
 }

--- a/plugins/korean-ipsum/src/ui/hooks/use-message-event-listner.ts
+++ b/plugins/korean-ipsum/src/ui/hooks/use-message-event-listner.ts
@@ -1,19 +1,27 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { FigmaPluginMessage } from '@/shared/types';
 import { useGlobalStore } from '../store';
+import { postUIPluginMessage } from '../utils/plugin-message';
 
 type PluginMessageEvent = MessageEvent<{
   pluginMessage: FigmaPluginMessage;
 }>;
 
 export function useMessageEventListener() {
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const updateIsSelectedTextNode = useGlobalStore(
     (state) => state.updateIsSelectedTextNode,
   );
+  const resetForm = useGlobalStore((state) => state.resetForm);
 
   const handleMessageEvent = useCallback(
     ({ data: { pluginMessage } }: PluginMessageEvent) => {
       switch (pluginMessage.type) {
+        case 'ON_INIT':
+          updateIsSelectedTextNode(pluginMessage.isSelectedTextNode);
+          resetForm(pluginMessage.formState);
+          setIsLoading(false);
+          break;
         case 'ON_CHANGE_SELECTION':
           updateIsSelectedTextNode(pluginMessage.isSelectedTextNode);
           break;
@@ -21,8 +29,14 @@ export function useMessageEventListener() {
           break;
       }
     },
-    [updateIsSelectedTextNode],
+    [updateIsSelectedTextNode, resetForm],
   );
+
+  useEffect(() => {
+    postUIPluginMessage({
+      type: 'INIT',
+    });
+  }, []);
 
   useEffect(() => {
     window.addEventListener('message', handleMessageEvent);
@@ -30,4 +44,6 @@ export function useMessageEventListener() {
       window.removeEventListener('message', handleMessageEvent);
     };
   }, [handleMessageEvent]);
+
+  return { isLoading };
 }

--- a/plugins/korean-ipsum/src/ui/store.ts
+++ b/plugins/korean-ipsum/src/ui/store.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
 import type { GenerateFormState } from '@/shared/types';
+import { postUIPluginMessage } from './utils/plugin-message';
 
 interface GlobalStoreState {
   isSelectedTextNode: boolean;
@@ -24,8 +26,8 @@ const initialState: GlobalStoreState = {
   },
 };
 
-export const useGlobalStore = create<GlobalStoreState & GlobalStoreAction>(
-  (set) => ({
+export const useGlobalStore = create(
+  subscribeWithSelector<GlobalStoreState & GlobalStoreAction>((set) => ({
     ...initialState,
     updateIsSelectedTextNode: (isSelectedTextNode) => {
       set(() => ({ isSelectedTextNode }));
@@ -39,5 +41,15 @@ export const useGlobalStore = create<GlobalStoreState & GlobalStoreAction>(
         },
       }));
     },
-  }),
+  })),
+);
+
+useGlobalStore.subscribe(
+  (state) => state.formState,
+  (formState) => {
+    postUIPluginMessage({
+      type: 'ON_CHANGE_FORM_STATE',
+      formState,
+    });
+  },
 );

--- a/plugins/korean-ipsum/src/ui/store.ts
+++ b/plugins/korean-ipsum/src/ui/store.ts
@@ -14,6 +14,7 @@ interface GlobalStoreAction {
     key: K,
     value: GenerateFormState[K],
   ) => void;
+  resetForm: (formState?: GenerateFormState) => void;
 }
 
 const initialState: GlobalStoreState = {
@@ -38,6 +39,14 @@ export const useGlobalStore = create(
         formState: {
           ...prevState.formState,
           [key]: value,
+        },
+      }));
+    },
+    resetForm: (formState) => {
+      set(() => ({
+        formState: {
+          ...initialState.formState,
+          ...formState,
         },
       }));
     },

--- a/plugins/korean-ipsum/src/ui/utils/plugin-message.ts
+++ b/plugins/korean-ipsum/src/ui/utils/plugin-message.ts
@@ -1,0 +1,10 @@
+import type { UIPluginMessage } from '@/shared/types';
+
+export function postUIPluginMessage(pluginMessage: UIPluginMessage) {
+  parent.postMessage(
+    {
+      pluginMessage,
+    },
+    'https://www.figma.com',
+  );
+}


### PR DESCRIPTION
## 변경사항
- 한글입숨(`korean-ipsum`) 플러그인의 `formState`를 `figma.clientStorage`와 동기화하여, 이전의 선택한 필드를 반영하는 기능 추가
  - `INIT`, `ON_INIT`, `ON_CHANGE_FORM_STATE` 이벤트 추가
  - `INIT`: UI에서 figma의 `clientStorage`로 상태를 불러오는 이벤트
  - `ON_INIT`: figma에서 UI로 `INIT`에 대한 응답을 보내는 이벤트
  - `ON_CHANGE_FORM_STATE`: `formState`가 변경될 때 마다, `figma.clientStorage`에 저장하는 이벤트

## 참조
- https://www.figma.com/plugin-docs/api/figma-clientStorage/