### PR TITLE
`Slider` 컴포넌트 추가

### DIFF
--- a/apps/docs/stories/components/slider/slider.docs.mdx
+++ b/apps/docs/stories/components/slider/slider.docs.mdx
@@ -1,0 +1,18 @@
+import { Meta, Primary, Controls, Source } from '@storybook/blocks';
+import * as SliderStories from './slider.stories';
+
+<Meta of={SliderStories} />
+
+# Select
+
+<Primary />
+
+## Props
+
+<Controls />
+
+## Usage
+
+### Import
+
+<Source code={`import { Slider } from '@figma-plugins/ui';`} />

--- a/apps/docs/stories/components/slider/slider.stories.tsx
+++ b/apps/docs/stories/components/slider/slider.stories.tsx
@@ -1,0 +1,35 @@
+import { Slider } from '@figma-plugins/ui';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/Slider',
+  component: Slider,
+  argTypes: {
+    disabled: {
+      control: 'boolean',
+    },
+  },
+} satisfies Meta<typeof Slider>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Slider
+      css={{ width: '50%' }}
+      defaultValue={[50]}
+      max={100}
+      step={1}
+      {...args}
+    />
+  ),
+  args: {
+    disabled: false,
+    min: 1,
+    max: 10,
+    step: 1,
+    defaultValue: [5],
+  },
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-radio-group": "^1.1.3",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-select": "^2.0.0",
+    "@radix-ui/react-slider": "^1.1.2",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",
     "@stitches/react": "^1.2.8"

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -20,3 +20,4 @@ export { Text, type TextVariantProps } from './text';
 export { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs';
 export { Toast, type ToastProps } from './toast';
 export { Toaster, useToast } from './toaster';
+export { Slider } from './slider';

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -1,0 +1,70 @@
+import * as SliderPrimitive from '@radix-ui/react-slider';
+import { forwardRef } from 'react';
+import { styled } from '@/stitches.config';
+import { colors } from '@/vars';
+
+const SliderRoot = styled(SliderPrimitive.Root, {
+  position: 'relative',
+  display: 'flex',
+  alignItems: 'center',
+  width: '$full',
+  userSelect: 'none',
+  touchAction: 'none',
+});
+
+const SliderTrack = styled(SliderPrimitive.Track, {
+  position: 'relative',
+  height: '$150',
+  width: '$full',
+  flexGrow: 1,
+  overflow: 'hidden',
+  borderRadius: '$full',
+  backgroundColor: colors.bg.disabled.default,
+  '&[data-disabled]': {
+    backgroundColor: colors.bg.disabled.default,
+  },
+});
+
+const SliderRange = styled(SliderPrimitive.Range, {
+  position: 'absolute',
+  height: '$full',
+  backgroundColor: colors.bg.brand.default,
+  '&[data-disabled]': {
+    backgroundColor: colors.bg.disabled.secondary,
+  },
+});
+
+const SliderThumb = styled(SliderPrimitive.Thumb, {
+  display: 'block',
+  width: '$400',
+  height: '$400',
+  borderWidth: '$1',
+  borderRadius: '$full',
+  borderColor: colors.border.brand.default,
+  backgroundColor: colors.icon.onbrand.default,
+  transitionProperty: '$transitions$shadow',
+  transitionDuration: '$transitions$200',
+  transitionTimingFunction: '$transitions$ease-out',
+  '&:focus-visible': {
+    outline: 'none',
+    boxShadow: `0 0 0 2px ${colors.border.onselected.default}`,
+  },
+  '&[data-disabled]': {
+    pointerEvents: 'none',
+    borderColor: colors.border.disabled.default,
+    backgroundColor: colors.icon.ondisabled,
+  },
+});
+
+export const Slider = forwardRef<
+  React.ElementRef<typeof SliderRoot>,
+  React.ComponentPropsWithoutRef<typeof SliderRoot>
+>((props, ref) => (
+  <SliderRoot ref={ref} {...props}>
+    <SliderTrack>
+      <SliderRange />
+    </SliderTrack>
+    <SliderThumb />
+  </SliderRoot>
+));
+Slider.displayName = 'Slider';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       '@radix-ui/react-select':
         specifier: ^2.0.0
         version: 2.0.0(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slider':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-tabs':
         specifier: ^1.0.4
         version: 1.0.4(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
@@ -2769,6 +2772,37 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: true
+
+  /@radix-ui/react-slider@1.1.2(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-NKs15MJylfzVsCagVSWKhGGLNR1W9qWs+HtgbmjjVUB3B9+lb3PYoXxVju3kOrpf0VKyVCtZp+iTwVoqpa1Chw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/number': 1.0.1
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.33)(react@18.2.0)
+      '@types/react': 18.2.33
+      '@types/react-dom': 18.2.14
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /@radix-ui/react-slot@1.0.2(@types/react@18.2.33)(react@18.2.0):
     resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}


### PR DESCRIPTION
## 변경사항
- `@radix-ui/react-slider` 기반의 `Slider` 컴포넌트 추가
- `Slider` 컴포넌트에 대한 `Story` 및 `Docs` 추가


## 참조
- https://www.radix-ui.com/primitives/docs/components/slider