### PR TITLE
생성 관련 Form의 구조 변경

### DIFF
--- a/plugins/korean-ipsum/src/code/handlers.ts
+++ b/plugins/korean-ipsum/src/code/handlers.ts
@@ -41,7 +41,7 @@ function getFormStateFromClientStorage(): Promise<GenerateFormState> {
   return getClientStorage('FORM_STATE', {
     source: 'countingStars',
     unit: 'word',
-    count: '1',
+    count: 1,
     method: 'replace',
   });
 }

--- a/plugins/korean-ipsum/src/shared/generate/generate.ts
+++ b/plugins/korean-ipsum/src/shared/generate/generate.ts
@@ -21,13 +21,7 @@ export function generatePragraph(source: string, count: number) {
   return createContent(count, () => generateSentence(source, 8), '\n\n');
 }
 
-export function generateContent({
-  unit,
-  count: countStr,
-  source,
-}: GenerateFormState) {
-  const count = parseInt(countStr, 10);
-
+export function generateContent({ unit, count, source }: GenerateFormState) {
   const dataSource = data[source];
   if (unit === 'word') {
     return generateWord(dataSource, count);

--- a/plugins/korean-ipsum/src/shared/types/generate-form.ts
+++ b/plugins/korean-ipsum/src/shared/types/generate-form.ts
@@ -1,6 +1,6 @@
 export type GenerateSource = 'countingStars' | 'mountain' | 'shower' | 'star';
 export type GenerateUnit = 'word' | 'sentence' | 'paragraph';
-export type GenerateCount = '1' | '2' | '3' | '4' | '5';
+export type GenerateCount = number;
 export type GenerateMethod = 'replace' | 'join';
 
 export interface GenerateFormState {

--- a/plugins/korean-ipsum/src/ui/components/index.ts
+++ b/plugins/korean-ipsum/src/ui/components/index.ts
@@ -1,2 +1,3 @@
 export { RadioGroupField } from './radio-group-field';
+export { RangeField } from './range-field';
 export { SelectField } from './select-field';

--- a/plugins/korean-ipsum/src/ui/components/range-field.tsx
+++ b/plugins/korean-ipsum/src/ui/components/range-field.tsx
@@ -1,0 +1,31 @@
+import { Flex, Text, Slider } from '@figma-plugins/ui';
+import { useId } from 'react';
+
+interface RangeFieldProps
+  extends React.ComponentPropsWithoutRef<typeof Slider> {
+  label: string;
+}
+
+export function RangeField({ label, value, css, ...props }: RangeFieldProps) {
+  const id = useId();
+
+  return (
+    <div>
+      <Text
+        as="label"
+        css={{ display: 'block', marginBottom: '$150' }}
+        htmlFor={id}
+        size="sm"
+        weight="semibold"
+      >
+        {label}
+      </Text>
+      <Flex gap="200" items="center">
+        <Slider css={{ ...css, flex: 1 }} {...props} />
+        <Text as="span" size="sm" weight="medium">
+          {value}개
+        </Text>
+      </Flex>
+    </div>
+  );
+}

--- a/plugins/korean-ipsum/src/ui/components/select-field.tsx
+++ b/plugins/korean-ipsum/src/ui/components/select-field.tsx
@@ -32,7 +32,7 @@ export function SelectField({ label, options, ...props }: SelectFieldProps) {
         <SelectTrigger id={id}>
           <SelectValue placeholder="텍스트 소스를 선택해주세요." />
         </SelectTrigger>
-        <SelectContent position="popper">
+        <SelectContent>
           {options.map((option) => (
             <SelectItem key={option.value} value={option.value}>
               {option.label}

--- a/plugins/korean-ipsum/src/ui/pages/form-page.tsx
+++ b/plugins/korean-ipsum/src/ui/pages/form-page.tsx
@@ -1,6 +1,5 @@
 import { Button, Flex } from '@figma-plugins/ui';
 import type {
-  GenerateCount,
   GenerateMethod,
   GenerateSource,
   GenerateUnit,
@@ -8,6 +7,7 @@ import type {
 import { useGlobalStore } from '../store';
 import { RadioGroupField, SelectField } from '../components';
 import { useGenerateContentEvent } from '../hooks';
+import { RangeField } from '../components/range-field';
 
 const GENERATE_SOURCES = [
   { value: 'countingStars', label: '별 헤는 밤' },
@@ -20,14 +20,6 @@ const GENERATE_UNITS = [
   { value: 'word', label: '단어' },
   { value: 'sentence', label: '문장' },
   { value: 'paragraph', label: '문단' },
-];
-
-const GENERATE_COUNTS = [
-  { value: '1', label: '1개' },
-  { value: '2', label: '2개' },
-  { value: '3', label: '3개' },
-  { value: '4', label: '4개' },
-  { value: '5', label: '5개' },
 ];
 
 const GENERATE_METHODS = [
@@ -50,7 +42,7 @@ export function FormPage() {
       as="form"
       css={{ height: '100vh', margin: 0, padding: '$400' }}
       direction="column"
-      gap="600"
+      gap="500"
       justify="between"
       onSubmit={handleSubmit}
     >
@@ -71,13 +63,15 @@ export function FormPage() {
           options={GENERATE_UNITS}
           value={formState.unit}
         />
-        <RadioGroupField
+        <RangeField
+          defaultValue={[formState.count]}
           label="생성 개수"
-          onValueChange={(value) => {
-            updateForm('count', value as GenerateCount);
+          max={10}
+          min={1}
+          onValueChange={([value]) => {
+            updateForm('count', value);
           }}
-          options={GENERATE_COUNTS}
-          value={formState.count}
+          value={[formState.count]}
         />
         <RadioGroupField
           label="생성 방식"

--- a/plugins/korean-ipsum/src/ui/pages/form-page.tsx
+++ b/plugins/korean-ipsum/src/ui/pages/form-page.tsx
@@ -16,7 +16,7 @@ const GENERATE_SOURCES = [
   { value: 'star', label: '별' },
 ];
 
-const GENREATE_UNITS = [
+const GENERATE_UNITS = [
   { value: 'word', label: '단어' },
   { value: 'sentence', label: '문장' },
   { value: 'paragraph', label: '문단' },
@@ -63,12 +63,12 @@ export function FormPage() {
           options={GENERATE_SOURCES}
           value={formState.source}
         />
-        <RadioGroupField
+        <SelectField
           label="생성 단위"
           onValueChange={(value) => {
             updateForm('unit', value as GenerateUnit);
           }}
-          options={GENREATE_UNITS}
+          options={GENERATE_UNITS}
           value={formState.unit}
         />
         <RadioGroupField

--- a/plugins/korean-ipsum/src/ui/pages/form-page.tsx
+++ b/plugins/korean-ipsum/src/ui/pages/form-page.tsx
@@ -5,9 +5,8 @@ import type {
   GenerateUnit,
 } from '@/shared/types';
 import { useGlobalStore } from '../store';
-import { RadioGroupField, SelectField } from '../components';
+import { RadioGroupField, SelectField, RangeField } from '../components';
 import { useGenerateContentEvent } from '../hooks';
-import { RangeField } from '../components/range-field';
 
 const GENERATE_SOURCES = [
   { value: 'countingStars', label: '별 헤는 밤' },

--- a/plugins/korean-ipsum/src/ui/store.ts
+++ b/plugins/korean-ipsum/src/ui/store.ts
@@ -22,7 +22,7 @@ const initialState: GlobalStoreState = {
   formState: {
     source: 'countingStars',
     unit: 'word',
-    count: '1',
+    count: 1,
     method: 'replace',
   },
 };


### PR DESCRIPTION
## 변경사항
- 기존의 `GenerateCount`의 `type`을 `number`로 변경
- `GenerateCount` 관련 필드를 `Slider`를 사용한, `Range`를 통한 변경 방식으로 변경
- `GenerateUnit` 관련 필드를 `Select`를 통한 변경 방식으로 변경
- `SelectField`의 `position`을 `popper` 형식이 아닌 기본 `item-aligned` 형식으로 변경