### PR TITLE
Github Actions의 CI Workflow 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,8 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  ci:
+  lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18]
-        pnpm-version: [8]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,25 +16,68 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: ${{ matrix.pnpm-version }}
+          version: 8
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20
           cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build
-        run: pnpm run build
+      - name: Build @figma-plugins/ui
+        run: pnpm run build --filter=@figma-plugins/ui
 
-      - name: Prettier check
+      - name: Check eslint
+        run: pnpm run lint:check
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Check prettier
         run: pnpm run format:check
 
-      - name: Lint check
-        run: pnpm run lint
+  tsc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Type check
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build @figma-plugins/ui
+        run: pnpm run build --filter=@figma-plugins/ui
+
+      - name: Check typescript
         run: pnpm run typecheck

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,8 +7,8 @@
     "build": "tsup",
     "clean": "rm -rf .turbo dist node_modules",
     "dev": "tsup --watch --onSuccess \"node dist/index.js\"",
-    "lint": "eslint ./src/**/*.ts",
-    "lint:fix": "pnpm lint --fix",
+    "lint": "eslint ./src/**/*.ts --fix",
+    "lint:check": "eslint ./src/**/*.ts --max-warnings=0",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,8 +7,8 @@
     "build": "storybook build --docs",
     "clean": "rm -rf .turbo storybook-static node_modules",
     "dev": "storybook dev -p 6006 --no-open",
-    "lint": "eslint '{.storybook,stories}/**/*.{ts,tsx}'",
-    "lint:fix": "pnpm lint --fix",
+    "lint": "eslint '{.storybook,stories}/**/*.{ts,tsx}' --fix",
+    "lint:check": "eslint '{.storybook,stories}/**/*.{ts,tsx}' --max-warnings=0",
     "start": "http-server storybook-static",
     "typecheck": "tsc --noEmit"
   },

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "prettier": "^3.0.3",
     "turbo": "^1.10.16"
   },
-  "packageManager": "pnpm@8.10.0",
+  "packageManager": "pnpm@8.15.5",
   "engines": {
-    "node": "18.x"
+    "node": "20.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format:check": "prettier -c --cache .",
     "gen:plugin": "turbo gen plugin",
     "lint": "turbo run lint",
-    "lint:fix": "turbo run lint:fix",
+    "lint:check": "turbo run lint:check",
     "typecheck": "turbo run typecheck"
   },
   "prettier": "@vercel/style-guide/prettier",

--- a/packages/config/webpack/package.json
+++ b/packages/config/webpack/package.json
@@ -7,8 +7,9 @@
   "types": "./src/index.d.ts",
   "scripts": {
     "clean": "rm -rf .turbo node_modules",
-    "lint": "eslint src",
-    "lint:fix": "pnpm lint --fix"
+    "lint": "eslint src --fix",
+    "lint:check": "eslint src --max-warnings=0",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "html-inline-script-webpack-plugin": "^3.2.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,8 +9,8 @@
     "build": "tsup",
     "clean": "rm -rf .turbo dist node_modules",
     "dev": "tsup --watch",
-    "lint": "eslint ./src/**/*.ts*",
-    "lint:fix": "pnpm lint --fix",
+    "lint": "eslint ./src/**/*.ts* --fix",
+    "lint:check": "eslint ./src/**/*.ts* --max-warnings=0",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/plugins/korean-ipsum/package.json
+++ b/plugins/korean-ipsum/package.json
@@ -6,8 +6,8 @@
     "build": "webpack",
     "clean": "rm -rf .turbo dist node_modules",
     "dev": "webpack --watch",
-    "lint": "eslint ./src/**/*.ts*",
-    "lint:fix": "pnpm lint --fix",
+    "lint": "eslint ./src/**/*.ts* --fix",
+    "lint:check": "eslint ./src/**/*.ts* --max-warnings=0",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/plugins/korean-spell-check/package.json
+++ b/plugins/korean-spell-check/package.json
@@ -6,8 +6,8 @@
     "build": "webpack",
     "clean": "rm -rf .turbo dist node_modules",
     "dev": "webpack --watch",
-    "lint": "eslint ./src/**/*.ts*",
-    "lint:fix": "pnpm lint --fix",
+    "lint": "eslint ./src/**/*.ts* --fix",
+    "lint:check": "eslint ./src/**/*.ts* --max-warnings=0",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,7 @@
     "lint": {
       "cache": true
     },
-    "lint:fix": {
+    "lint:check": {
       "cache": true
     },
     "typecheck": {


### PR DESCRIPTION
## 변경사항
- `eslint` 관련 스크립트 이름 수정
  - `lint:fix` -> `lint`
  - `lint` -> `lint:check`
- `node` 버전을 20으로 변경
- 기존의 하나의 `job`을 `lint`, `format`, `tsc`으로 분리
