### PR TITLE
`@figma-plugins/prettier-config` 패키지 추가

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,2 @@
 dist/
-
 pnpm-lock.yaml
-
-*.hbs

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,11 +7,13 @@
     "build": "tsup",
     "clean": "rm -rf .turbo dist node_modules",
     "dev": "tsup --watch --onSuccess 'node dist/index.js'",
+    "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint 'src/**/*.ts' --fix",
     "lint:check": "eslint 'src/**/*.ts' --max-warnings=0",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit"
   },
+  "prettier": "@figma-plugins/prettier-config",
   "dependencies": {
     "@fastify/env": "^4.3.0",
     "fastify": "^4.26.2",
@@ -20,6 +22,7 @@
   },
   "devDependencies": {
     "@figma-plugins/eslint-config": "workspace:*",
+    "@figma-plugins/prettier-config": "workspace:*",
     "@figma-plugins/tsconfig": "workspace:*",
     "@types/node": "catalog:",
     "tsup": "catalog:",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,11 +7,13 @@
     "build": "storybook build --docs",
     "clean": "rm -rf .turbo storybook-static node_modules",
     "dev": "storybook dev -p 6006 --no-open",
+    "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint '{.storybook,stories}/**/*.{ts,tsx}' --fix",
     "lint:check": "eslint '{.storybook,stories}/**/*.{ts,tsx}' --max-warnings=0",
     "start": "http-server storybook-static",
     "typecheck": "tsc --noEmit"
   },
+  "prettier": "@figma-plugins/prettier-config",
   "dependencies": {
     "@figma-plugins/ui": "workspace:*",
     "@radix-ui/react-icons": "^1.3.0",
@@ -20,6 +22,7 @@
   },
   "devDependencies": {
     "@figma-plugins/eslint-config": "workspace:*",
+    "@figma-plugins/prettier-config": "workspace:*",
     "@figma-plugins/tsconfig": "workspace:*",
     "@storybook/addon-essentials": "^7.5.2",
     "@storybook/addon-interactions": "^7.5.2",

--- a/package.json
+++ b/package.json
@@ -9,19 +9,19 @@
     "build": "turbo run build",
     "clean:workspace": "turbo run clean",
     "dev": "turbo run dev",
-    "format": "prettier -w --cache .",
-    "format:check": "prettier -c --cache .",
+    "format": "turbo run format -- --write --cache",
+    "format:check": "turbo run format -- --cache",
     "gen:plugin": "turbo gen plugin",
     "lint": "turbo run lint",
     "lint:check": "turbo run lint:check",
     "typecheck": "turbo run typecheck"
   },
-  "prettier": "@vercel/style-guide/prettier",
+  "prettier": "@figma-plugins/prettier-config",
   "devDependencies": {
     "@figma-plugins/eslint-config": "workspace:*",
+    "@figma-plugins/prettier-config": "workspace:*",
     "@figma-plugins/tsconfig": "workspace:*",
     "@turbo/gen": "catalog:turbo",
-    "@vercel/style-guide": "^6.0.0",
     "eslint": "catalog:",
     "prettier": "catalog:",
     "turbo": "catalog:turbo"

--- a/packages/config/eslint/package.json
+++ b/packages/config/eslint/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "clean": "rm -rf .turbo node_modules"
+    "clean": "rm -rf .turbo node_modules",
+    "format": "prettier --check . --ignore-path ../../../.gitignore"
   },
+  "prettier": "@figma-plugins/prettier-config",
   "dependencies": {
     "@vercel/style-guide": "^6.0.0",
     "eslint-config-turbo": "catalog:turbo",
@@ -13,6 +15,7 @@
     "eslint-plugin-storybook": "^0.11.1"
   },
   "devDependencies": {
+    "@figma-plugins/prettier-config": "workspace:*",
     "@types/eslint": "^8.56.10",
     "typescript": "catalog:"
   },

--- a/packages/config/prettier/index.js
+++ b/packages/config/prettier/index.js
@@ -10,6 +10,39 @@ const config = {
   singleQuote: true,
   endOfLine: 'lf',
   plugins: ['prettier-plugin-packagejson'],
+
+  overrides: [
+    {
+      files: '*.html.hbs',
+      options: {
+        parser: 'html',
+      },
+    },
+    {
+      files: '*.json.hbs',
+      options: {
+        parser: 'json',
+      },
+    },
+    {
+      files: '*.json.hbs',
+      options: {
+        parser: 'json',
+      },
+    },
+    {
+      files: '*.{js,cjs,mjs}.hbs',
+      options: {
+        parser: 'babel',
+      },
+    },
+    {
+      files: '*.{ts,tsx}.hbs',
+      options: {
+        parser: 'typescript',
+      },
+    },
+  ],
 };
 
 // eslint-disable-next-line import/no-default-export -- 'configuration file should be use default export'

--- a/packages/config/prettier/index.js
+++ b/packages/config/prettier/index.js
@@ -1,0 +1,16 @@
+/** @typedef {import("prettier").Config} PrettierConfig */
+
+/** @type { PrettierConfig } */
+const config = {
+  printWidth: 80,
+  tabWidth: 2,
+  useTabs: false,
+  semi: true,
+  trailingComma: 'all',
+  singleQuote: true,
+  endOfLine: 'lf',
+  plugins: ['prettier-plugin-packagejson'],
+};
+
+// eslint-disable-next-line import/no-default-export -- 'configuration file should be use default export'
+export default config;

--- a/packages/config/prettier/package.json
+++ b/packages/config/prettier/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@figma-plugins/prettier-config",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo node_modules",
+    "format": "prettier --check . --ignore-path ../../../.gitignore"
+  },
+  "prettier": "@figma-plugins/prettier-config",
+  "dependencies": {
+    "prettier": "catalog:",
+    "prettier-plugin-packagejson": "^2.5.6"
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,10 +9,12 @@
     "build": "tsup",
     "clean": "rm -rf .turbo dist node_modules",
     "dev": "tsup --watch",
+    "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint './src/**/*.{ts,tsx}' --fix",
     "lint:check": "eslint './src/**/*.{ts,tsx}' --max-warnings=0",
     "typecheck": "tsc --noEmit"
   },
+  "prettier": "@figma-plugins/prettier-config",
   "dependencies": {
     "@radix-ui/react-popover": "^1.1.2",
     "@radix-ui/react-radio-group": "^1.2.1",
@@ -25,6 +27,7 @@
   },
   "devDependencies": {
     "@figma-plugins/eslint-config": "workspace:*",
+    "@figma-plugins/prettier-config": "workspace:*",
     "@figma-plugins/tsconfig": "workspace:*",
     "@radix-ui/react-icons": "^1.3.2",
     "@types/node": "catalog:",

--- a/plugins/korean-ipsum/package.json
+++ b/plugins/korean-ipsum/package.json
@@ -6,10 +6,12 @@
     "build": "webpack",
     "clean": "rm -rf .turbo dist node_modules",
     "dev": "webpack --watch",
+    "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint './src/**/*.{ts,tsx}' --fix",
     "lint:check": "eslint './src/**/*.{ts,tsx}' --max-warnings=0",
     "typecheck": "tsc --noEmit"
   },
+  "prettier": "@figma-plugins/prettier-config",
   "dependencies": {
     "@figma-plugins/ui": "workspace:*",
     "@radix-ui/react-icons": "^1.3.2",
@@ -19,6 +21,7 @@
   },
   "devDependencies": {
     "@figma-plugins/eslint-config": "workspace:*",
+    "@figma-plugins/prettier-config": "workspace:*",
     "@figma-plugins/tsconfig": "workspace:*",
     "@figma-plugins/webpack-config": "workspace:*",
     "@figma/plugin-typings": "catalog:",

--- a/plugins/korean-spell-check/package.json
+++ b/plugins/korean-spell-check/package.json
@@ -6,10 +6,12 @@
     "build": "webpack",
     "clean": "rm -rf .turbo dist node_modules",
     "dev": "webpack --watch",
+    "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint './src/**/*.{ts,tsx}' --fix",
     "lint:check": "eslint './src/**/*.{ts,tsx}' --max-warnings=0",
     "typecheck": "tsc --noEmit"
   },
+  "prettier": "@figma-plugins/prettier-config",
   "dependencies": {
     "@figma-plugins/ui": "workspace:*",
     "@radix-ui/react-icons": "^1.3.2",
@@ -19,6 +21,7 @@
   },
   "devDependencies": {
     "@figma-plugins/eslint-config": "workspace:*",
+    "@figma-plugins/prettier-config": "workspace:*",
     "@figma-plugins/tsconfig": "workspace:*",
     "@figma-plugins/webpack-config": "workspace:*",
     "@figma/plugin-typings": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,15 +61,15 @@ importers:
       '@figma-plugins/eslint-config':
         specifier: workspace:*
         version: link:packages/config/eslint
+      '@figma-plugins/prettier-config':
+        specifier: workspace:*
+        version: link:packages/config/prettier
       '@figma-plugins/tsconfig':
         specifier: workspace:*
         version: link:packages/config/tsconfig
       '@turbo/gen':
         specifier: catalog:turbo
         version: 2.3.3(@types/node@20.17.9)(typescript@5.7.2)
-      '@vercel/style-guide':
-        specifier: ^6.0.0
-        version: 6.0.0(eslint@8.57.1)(prettier@3.4.2)(typescript@5.7.2)
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
@@ -98,6 +98,9 @@ importers:
       '@figma-plugins/eslint-config':
         specifier: workspace:*
         version: link:../../packages/config/eslint
+      '@figma-plugins/prettier-config':
+        specifier: workspace:*
+        version: link:../../packages/config/prettier
       '@figma-plugins/tsconfig':
         specifier: workspace:*
         version: link:../../packages/config/tsconfig
@@ -129,6 +132,9 @@ importers:
       '@figma-plugins/eslint-config':
         specifier: workspace:*
         version: link:../../packages/config/eslint
+      '@figma-plugins/prettier-config':
+        specifier: workspace:*
+        version: link:../../packages/config/prettier
       '@figma-plugins/tsconfig':
         specifier: workspace:*
         version: link:../../packages/config/tsconfig
@@ -202,6 +208,9 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1(eslint@8.57.1)(typescript@5.7.2)
     devDependencies:
+      '@figma-plugins/prettier-config':
+        specifier: workspace:*
+        version: link:../prettier
       '@types/eslint':
         specifier: ^8.56.10
         version: 8.56.12
@@ -278,6 +287,9 @@ importers:
       '@figma-plugins/eslint-config':
         specifier: workspace:*
         version: link:../config/eslint
+      '@figma-plugins/prettier-config':
+        specifier: workspace:*
+        version: link:../config/prettier
       '@figma-plugins/tsconfig':
         specifier: workspace:*
         version: link:../config/tsconfig
@@ -324,6 +336,9 @@ importers:
       '@figma-plugins/eslint-config':
         specifier: workspace:*
         version: link:../../packages/config/eslint
+      '@figma-plugins/prettier-config':
+        specifier: workspace:*
+        version: link:../../packages/config/prettier
       '@figma-plugins/tsconfig':
         specifier: workspace:*
         version: link:../../packages/config/tsconfig
@@ -373,6 +388,9 @@ importers:
       '@figma-plugins/eslint-config':
         specifier: workspace:*
         version: link:../../packages/config/eslint
+      '@figma-plugins/prettier-config':
+        specifier: workspace:*
+        version: link:../../packages/config/prettier
       '@figma-plugins/tsconfig':
         specifier: workspace:*
         version: link:../../packages/config/tsconfig

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,15 @@ importers:
         specifier: 'catalog:'
         version: 5.7.2
 
+  packages/config/prettier:
+    dependencies:
+      prettier:
+        specifier: 'catalog:'
+        version: 3.4.2
+      prettier-plugin-packagejson:
+        specifier: ^2.5.6
+        version: 2.5.6(prettier@3.4.2)
+
   packages/config/tsconfig: {}
 
   packages/config/webpack:
@@ -4313,6 +4322,14 @@ packages:
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
+  fdir@6.4.2:
+    resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fetch-retry@5.0.6:
     resolution: {integrity: sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==}
 
@@ -5825,6 +5842,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -5897,6 +5918,14 @@ packages:
 
   prettier-plugin-packagejson@2.4.13:
     resolution: {integrity: sha512-n64Y3E1iEese0RN0EmxM6E7dAiy47UPJOFyAjMNfZWPKQ1exwaaMTXEhK7vKIrbXLSmf2J9y4H5rnE1VII1vRg==}
+    peerDependencies:
+      prettier: '>= 1.16.0'
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
+  prettier-plugin-packagejson@2.5.6:
+    resolution: {integrity: sha512-TY7KiLtyt6Tlf53BEbXUWkN0+TRdHKgIMmtXtDCyHH6yWnZ50Lwq6Vb6lyjapZrhDTXooC4EtlY5iLe1sCgi5w==}
     peerDependencies:
       prettier: '>= 1.16.0'
     peerDependenciesMeta:
@@ -6460,6 +6489,10 @@ packages:
   sort-object-keys@1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
 
+  sort-package-json@2.12.0:
+    resolution: {integrity: sha512-/HrPQAeeLaa+vbAH/znjuhwUluuiM/zL5XX9kop8UpDgjtyWKt43hGDk2vd/TBdDpzIyzIHVUgmYofzYrAQjew==}
+    hasBin: true
+
   sort-package-json@2.9.0:
     resolution: {integrity: sha512-vlEd6i57Eb9+ruta1+hID+emmAmGzWKraEX1kk5LAQ0k1glgDHOENeieqzfir0m8MHcebzDH4FEwqjPnMEjy2g==}
     hasBin: true
@@ -6635,6 +6668,10 @@ packages:
     resolution: {integrity: sha512-7RnqIMq572L8PeEzKeBINYEJDDxpcH8JEgLwUqBd3TkofhFRbkq4QLR0u+36avGAhCRbk2nnmjcW9SE531hPDg==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  synckit@0.9.2:
+    resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
@@ -6714,6 +6751,10 @@ packages:
 
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
+
+  tinyglobby@0.2.10:
+    resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
+    engines: {node: '>=12.0.0'}
 
   tinygradient@1.1.5:
     resolution: {integrity: sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==}
@@ -12368,6 +12409,10 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
+  fdir@6.4.2(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
   fetch-retry@5.0.6: {}
 
   figures@3.2.0:
@@ -14167,6 +14212,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   pify@4.0.1: {}
 
   pino-abstract-transport@1.1.0:
@@ -14257,6 +14304,13 @@ snapshots:
     dependencies:
       sort-package-json: 2.9.0
       synckit: 0.9.0
+    optionalDependencies:
+      prettier: 3.4.2
+
+  prettier-plugin-packagejson@2.5.6(prettier@3.4.2):
+    dependencies:
+      sort-package-json: 2.12.0
+      synckit: 0.9.2
     optionalDependencies:
       prettier: 3.4.2
 
@@ -14944,6 +14998,17 @@ snapshots:
 
   sort-object-keys@1.1.3: {}
 
+  sort-package-json@2.12.0:
+    dependencies:
+      detect-indent: 7.0.1
+      detect-newline: 4.0.1
+      get-stdin: 9.0.0
+      git-hooks-list: 3.1.0
+      is-plain-obj: 4.1.0
+      semver: 7.6.2
+      sort-object-keys: 1.1.3
+      tinyglobby: 0.2.10
+
   sort-package-json@2.9.0:
     dependencies:
       detect-indent: 7.0.1
@@ -15150,6 +15215,11 @@ snapshots:
       '@pkgr/core': 0.1.1
       tslib: 2.6.2
 
+  synckit@0.9.2:
+    dependencies:
+      '@pkgr/core': 0.1.1
+      tslib: 2.6.2
+
   tapable@2.2.1: {}
 
   tar-fs@2.1.1:
@@ -15240,6 +15310,11 @@ snapshots:
   tiny-invariant@1.3.1: {}
 
   tinycolor2@1.6.0: {}
+
+  tinyglobby@0.2.10:
+    dependencies:
+      fdir: 6.4.2(picomatch@4.0.2)
+      picomatch: 4.0.2
 
   tinygradient@1.1.5:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,10 @@
       "cache": false,
       "persistent": true
     },
+    "format": {
+      "cache": true,
+      "outputLogs": "new-only"
+    },
     "lint": {
       "cache": true
     },

--- a/turbo/generators/templates/plugin/app.tsx.hbs
+++ b/turbo/generators/templates/plugin/app.tsx.hbs
@@ -5,7 +5,7 @@ export function App() {
 
   return (
     <div>
-      <h1>{{name}}</h1>
+      <h1>{{ name }}</h1>
     </div>
   );
 }

--- a/turbo/generators/templates/plugin/tsconfig.json.hbs
+++ b/turbo/generators/templates/plugin/tsconfig.json.hbs
@@ -1,7 +1,7 @@
 {
   "extends": "@figma-plugins/tsconfig/figma-plugin.json",
   "compilerOptions": {
-  "outDir": "dist",
+    "outDir": "dist",
     "typeRoots": ["./node_modules/@types", "./node_modules/@figma"],
     "baseUrl": ".",
     "paths": {

--- a/turbo/generators/templates/plugin/ui.html.hbs
+++ b/turbo/generators/templates/plugin/ui.html.hbs
@@ -1,1 +1,1 @@
-<div id="root"></div>
+<div id='root'></div>


### PR DESCRIPTION
## 변경사항
- `@figma-plugins/prettier-config` 패키지 추가
  - 기존 `@vercel/style-guide`의 `prettier` 설정을 사용하던 것에서, 공통으로 사용되는 `prettier` 설정을 관리하기 위한 패키지 추가
  - 포맷팅이 필요한 패키지에 `@figma-plugins/prettier-config` 의존성 및 `prettier` 설정 추가
- `prettier` 관련 스크립트 추가
  - 포맷팅이 필요한 패키지의 `format` 관련 스크립트 추가
  - 기존 `root`에서 하나의 `format` 스크립트를 사용하던 것에서, `turbo`의 `format` 스크립트를 사용하도록 변경
- `.hbs`에 대한 `prettier` 설정 추가
  - 각 `.hbs` 파일에 대한 [`parser`](https://prettier.io/docs/en/options#parser)를 다르게 사용하도록 설정
  - `.prettierignore`에서 `.hbs` 삭제
